### PR TITLE
Add local analytics tracking

### DIFF
--- a/src/components/Analytics.jsx
+++ b/src/components/Analytics.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+function Analytics({ analytics }) {
+  const { tasksCompleted, history } = analytics
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg p-6 mt-8">
+      <h2 className="text-xl font-bold mb-4 text-gray-800">Analytics</h2>
+      <p className="mb-4 text-gray-700">Tasks completed: {tasksCompleted}</p>
+      {history.length === 0 ? (
+        <p className="text-gray-500 italic">No tasks completed yet.</p>
+      ) : (
+        <ul className="space-y-1">
+          {history.map((item, index) => (
+            <li
+              key={index}
+              className="flex justify-between border-b border-gray-200 pb-1 text-sm"
+            >
+              <span className="text-gray-800 truncate">{item.text}</span>
+              <span className="text-gray-600">{item.pomodoros} Pomodoros</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default Analytics

--- a/src/components/RouletteWheel.jsx
+++ b/src/components/RouletteWheel.jsx
@@ -1,12 +1,13 @@
 import { useState, useRef, useEffect } from 'react'
 
-function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted }) {
+function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted, onPomodoroComplete }) {
   const [isSpinning, setIsSpinning] = useState(false)
   const [selectedTask, setSelectedTask] = useState(null)
   const [timeLeft, setTimeLeft] = useState(0)
   const wheelRef = useRef(null)
   const timerRef = useRef(null)
   const spinSoundRef = useRef(null)
+  const prevTimeLeftRef = useRef(timeLeft)
 
   const colors = [
     '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7',
@@ -131,6 +132,7 @@ function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted }) {
   }
 
   const startTimer = () => {
+    prevTimeLeftRef.current = 25 * 60
     setTimeLeft(25 * 60)
   }
 
@@ -153,20 +155,25 @@ function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted }) {
   }
 
   useEffect(() => {
-    // Clear any existing timeout first
     clearTimeout(timerRef.current)
-    
+
     if (timeLeft > 0 && selectedTask) {
       document.title = `${formatTime(timeLeft)} Pomodoro Roulette`
       timerRef.current = setTimeout(() => setTimeLeft(prev => prev - 1), 1000)
     } else if (timeLeft === 0 && selectedTask) {
-      // Timer just completed - play sound only once
       document.title = 'Pomodoro Roulette - Timer Complete!'
-      playCompletionSound()
+      if (prevTimeLeftRef.current > 0) {
+        playCompletionSound()
+        if (onPomodoroComplete) {
+          onPomodoroComplete(selectedTask.id)
+        }
+      }
     } else {
       document.title = 'Pomodoro Roulette'
     }
-    
+
+    prevTimeLeftRef.current = timeLeft
+
     return () => clearTimeout(timerRef.current)
   }, [timeLeft, selectedTask])
 


### PR DESCRIPTION
## Summary
- add new Analytics component to display completion data
- track pomodoro sessions and completed tasks in App
- notify App when a pomodoro finishes from the wheel
- persist analytics to localStorage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857113fc6d88333accd420b5d6cc19c