### PR TITLE
Add settings modal

### DIFF
--- a/src/components/RouletteWheel.jsx
+++ b/src/components/RouletteWheel.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import DiceIcon from './icons/DiceIcon'
 import ChevronIcon from './icons/ChevronIcon'
 import SettingsIcon from './icons/SettingsIcon'
+import SettingsModal from './SettingsModal'
 
 function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted, startTaskId, onStartTaskConsumed }) {
   const [isSpinning, setIsSpinning] = useState(false)
@@ -419,39 +420,15 @@ function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted, startTaskId, on
       )}
     </div>
     {showSettings && (
-      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-20">
-        <div className="bg-bg-card p-6 rounded-md w-80">
-          <h2 className="text-xl mb-4">Settings</h2>
-          <div className="mb-4">
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={soundsEnabled}
-                onChange={(e) => setSoundsEnabled(e.target.checked)}
-              />
-              <span>Enable Sounds</span>
-            </label>
-          </div>
-          <div className="mb-4">
-            <label className="block mb-1">Pomodoro Duration (minutes)</label>
-            <input
-              type="number"
-              min="1"
-              value={pomodoroDuration}
-              onChange={(e) => setPomodoroDuration(Number(e.target.value))}
-              className="w-full px-2 py-1 rounded bg-bg-secondary"
-            />
-          </div>
-          <div className="text-right">
-            <button
-              onClick={() => setShowSettings(false)}
-              className="px-4 py-2 bg-accent-primary text-white rounded hover:bg-red-600"
-            >
-              Close
-            </button>
-          </div>
-        </div>
-      </div>
+      <SettingsModal
+        initialSoundsEnabled={soundsEnabled}
+        initialPomodoroDuration={pomodoroDuration}
+        onSave={({ soundsEnabled: se, pomodoroDuration: pd }) => {
+          setSoundsEnabled(se)
+          setPomodoroDuration(pd)
+        }}
+        onClose={() => setShowSettings(false)}
+      />
     )}
     </>
   )

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+
+function SettingsModal({ initialSoundsEnabled, initialPomodoroDuration, onSave, onClose }) {
+  const [sounds, setSounds] = useState(initialSoundsEnabled)
+  const [duration, setDuration] = useState(initialPomodoroDuration)
+
+  const handleSave = () => {
+    onSave({ soundsEnabled: sounds, pomodoroDuration: duration })
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-20">
+      <div className="bg-bg-card p-6 rounded-md w-80">
+        <h2 className="text-xl mb-4">Settings</h2>
+        <div className="mb-4">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={sounds}
+              onChange={(e) => setSounds(e.target.checked)}
+            />
+            <span>Enable Sounds</span>
+          </label>
+        </div>
+        <div className="mb-4">
+          <label className="block mb-1">Pomodoro Duration (minutes)</label>
+          <input
+            type="number"
+            min="1"
+            value={duration}
+            onChange={(e) => setDuration(Number(e.target.value))}
+            className="w-full px-2 py-1 rounded bg-bg-secondary"
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-bg-secondary text-white rounded hover:bg-bg-secondary/80"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-4 py-2 bg-accent-primary text-white rounded hover:bg-red-600"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SettingsModal

--- a/src/components/icons/SettingsIcon.jsx
+++ b/src/components/icons/SettingsIcon.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export default function SettingsIcon({ className }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 15.5a3.5 3.5 0 100-7 3.5 3.5 0 000 7z"
+        fill="currentColor"
+      />
+      <path
+        d="M19.4 13a7.952 7.952 0 000-2l2.1-1.7a.5.5 0 00.1-.6l-2-3.5a.5.5 0 00-.6-.2l-2.5 1a8.06 8.06 0 00-1.7-1l-.4-2.6a.5.5 0 00-.5-.4h-4a.5.5 0 00-.5.4l-.4 2.6a8.06 8.06 0 00-1.7 1l-2.5-1a.5.5 0 00-.6.2l-2 3.5a.5.5 0 00.1.6L4.6 11a7.952 7.952 0 000 2l-2.1 1.7a.5.5 0 00-.1.6l2 3.5a.5.5 0 00.6.2l2.5-1a8.06 8.06 0 001.7 1l.4 2.6a.5.5 0 00.5.4h4a.5.5 0 00.5-.4l.4-2.6a8.06 8.06 0 001.7-1l2.5 1a.5.5 0 00.6-.2l2-3.5a.5.5 0 00-.1-.6L19.4 13z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
- add new settings icon
- allow toggling sounds and pomodoro duration
- persist settings to local storage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685753d5e788833389c52e6b7365ac4f