### PR TITLE
Add local analytics tracking

### DIFF
--- a/src/components/Analytics.jsx
+++ b/src/components/Analytics.jsx
@@ -1,0 +1,38 @@
+import TomatoIcon from './icons/TomatoIcon'
+
+function Analytics({ analytics }) {
+  const today = new Date().toISOString().slice(0, 10)
+  const todayCount = analytics.dailyPomodoros[today] || 0
+
+  return (
+    <div className="bg-bg-card rounded-md shadow-lg p-6">
+      <h2 className="mb-4">Analytics</h2>
+      <p className="mb-4 flex items-center gap-2">
+        <TomatoIcon className="w-5 h-5" />
+        <span>Pomodoros today: {todayCount}</span>
+      </p>
+      <div className="space-y-2">
+        <h3 className="font-semibold text-gray-300 mb-2">Completed Tasks</h3>
+        {analytics.completedTasks.length === 0 ? (
+          <p className="text-gray-400 italic">No tasks completed yet.</p>
+        ) : (
+          <ul className="space-y-1 max-h-[200px] overflow-y-auto">
+            {analytics.completedTasks.map((task) => (
+              <li
+                key={task.id}
+                className="flex justify-between items-center p-2 bg-bg-secondary rounded-md"
+              >
+                <span className="truncate" title={task.text}>{task.text}</span>
+                <span className="text-sm text-white/70 whitespace-nowrap">
+                  {task.pomodoros} 🍅
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default Analytics

--- a/src/components/TaskManager.jsx
+++ b/src/components/TaskManager.jsx
@@ -48,7 +48,12 @@ function TaskManager({ tasks, onAddTask, onDeleteTask, onStartTimer }) {
                 key={task.id}
                 className="flex items-center justify-between p-3 bg-bg-secondary rounded-md"
               >
-                <span className="text-text-primary truncate">{task.text}</span>
+                <span className="text-text-primary truncate" title={task.text}>
+                  {task.text}
+                </span>
+                <span className="text-sm text-white/70 mr-2 whitespace-nowrap">
+                  {task.pomodoros} 🍅
+                </span>
                 <div className="flex items-center gap-2">
                   <button
                     aria-label={`Start timer for task '${task.text}'`}


### PR DESCRIPTION
## Summary
- track pomodoro completions for each task
- store and show analytics data (daily pomodoro count and completed tasks)
- display pomodoro counts for tasks in list
- persist analytics to localStorage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68575306209c8333baf239ef47149ada