### PR TITLE
Add tooltip and delete confirmation to tasks

### DIFF
--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -1,0 +1,51 @@
+import PlayIcon from './icons/PlayIcon'
+import TrashIcon from './icons/TrashIcon'
+
+function TaskItem({
+  task,
+  onStartTimer,
+  onDeleteTask,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}) {
+  const handleDelete = () => {
+    if (window.confirm(`Delete task "${task.text}"?`)) {
+      onDeleteTask(task.id)
+    }
+  }
+
+  return (
+    <li
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+      className="flex items-center justify-between p-3 bg-bg-secondary rounded-md cursor-move"
+    >
+      <span className="text-text-primary truncate">{task.text}</span>
+      <div className="flex items-center gap-2">
+        <button
+          aria-label={`Start timer for task '${task.text}'`}
+          title="Start timer"
+          onClick={() => onStartTimer(task.id)}
+          className="p-1 text-text-primary/70 hover:text-accent-success"
+        >
+          <PlayIcon className="w-5 h-5" />
+        </button>
+        <button
+          aria-label={`Delete task '${task.text}'`}
+          title="Delete task"
+          onClick={handleDelete}
+          className="p-1 text-text-primary/70 hover:text-accent-primary"
+        >
+          <TrashIcon className="w-5 h-5" />
+        </button>
+      </div>
+    </li>
+  )
+}
+
+export default TaskItem

--- a/src/components/TaskManager.jsx
+++ b/src/components/TaskManager.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
-import TrashIcon from './icons/TrashIcon'
-import PlayIcon from './icons/PlayIcon'
+import TaskItem from './TaskItem'
 
 function TaskManager({ tasks, onAddTask, onDeleteTask, onStartTimer, onReorderTasks }) {
   const [newTask, setNewTask] = useState('')
@@ -64,33 +63,16 @@ function TaskManager({ tasks, onAddTask, onDeleteTask, onStartTimer, onReorderTa
         ) : (
           <ul className="space-y-2 max-h-[400px] overflow-y-auto">
             {tasks.map((task, index) => (
-              <li
+              <TaskItem
                 key={task.id}
-                draggable
+                task={task}
+                onStartTimer={onStartTimer}
+                onDeleteTask={onDeleteTask}
                 onDragStart={handleDragStart(index)}
                 onDragOver={handleDragOver}
                 onDrop={handleDrop(index)}
                 onDragEnd={handleDragEnd}
-                className="flex items-center justify-between p-3 bg-bg-secondary rounded-md cursor-move"
-              >
-                <span className="text-text-primary truncate">{task.text}</span>
-                <div className="flex items-center gap-2">
-                  <button
-                    aria-label={`Start timer for task '${task.text}'`}
-                    onClick={() => onStartTimer(task.id)}
-                    className="p-1 text-text-primary/70 hover:text-accent-success"
-                  >
-                    <PlayIcon className="w-5 h-5" />
-                  </button>
-                  <button
-                    aria-label={`Delete task '${task.text}'`}
-                    onClick={() => onDeleteTask(task.id)}
-                    className="p-1 text-text-primary/70 hover:text-accent-primary"
-                  >
-                    <TrashIcon className="w-5 h-5" />
-                  </button>
-                </div>
-              </li>
+              />
             ))}
           </ul>
         )}


### PR DESCRIPTION
## Summary
- introduce `TaskItem` component for individual task entries
- show tooltips on start and delete task buttons
- confirm task deletion with alert
- clean up `TaskManager` by using the new component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857561bd4e483338fd9c15e635985d4