### PR TITLE
Show pomodoro count per task

### DIFF
--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -25,7 +25,10 @@ function TaskItem({
       onDragEnd={onDragEnd}
       className="flex items-center justify-between p-3 bg-bg-secondary rounded-md cursor-move"
     >
-      <span className="text-text-primary truncate">{task.text}</span>
+      <div className="flex items-center gap-2 flex-1 min-w-0">
+        <span className="text-text-primary truncate">{task.text}</span>
+        <span className="text-accent-success text-sm whitespace-nowrap">{task.pomodoros} 🍅</span>
+      </div>
       <div className="flex items-center gap-2">
         <button
           aria-label={`Start timer for task '${task.text}'`}


### PR DESCRIPTION
## Summary
- display number of finished pomodoros next to each task name

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857599f57d08333866984e01c93839f