### PR TITLE
Fix infinite pomodoro increment after timer ends

### DIFF
--- a/src/hooks/usePomodoroTimer.js
+++ b/src/hooks/usePomodoroTimer.js
@@ -38,6 +38,7 @@ export default function usePomodoroTimer(durationMinutes, onComplete) {
       }
     } else if (timeLeft === 0 && timerStarted) {
       onComplete?.()
+      setTimerStarted(false)
     }
 
     return () => clearTimeout(timerRef.current)


### PR DESCRIPTION
## Summary
- stop timer to avoid repeated completion callbacks

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857604f531483339d86e4b5c244a07c