### PR TITLE
Add roulette completion sound and trim timer audio

### DIFF
--- a/src/components/RouletteWheel.jsx
+++ b/src/components/RouletteWheel.jsx
@@ -123,52 +123,63 @@ function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted, onPomodoroCompl
     }
   }
 
+  const playSelectionSound = () => {
+    if (!soundsEnabled) return
+    try {
+      const audioContext = new (window.AudioContext || window.webkitAudioContext)()
+
+      const oscillator = audioContext.createOscillator()
+      const gainNode = audioContext.createGain()
+
+      oscillator.connect(gainNode)
+      gainNode.connect(audioContext.destination)
+
+      const now = audioContext.currentTime
+      oscillator.frequency.setValueAtTime(880, now)
+      oscillator.type = 'triangle'
+
+      gainNode.gain.setValueAtTime(0, now)
+      gainNode.gain.linearRampToValueAtTime(0.2, now + 0.01)
+      gainNode.gain.exponentialRampToValueAtTime(0.01, now + 0.3)
+
+      oscillator.start(now)
+      oscillator.stop(now + 0.3)
+    } catch (error) {
+      console.log('Selection sound not supported:', error)
+    }
+  }
+
   const playCompletionSound = () => {
     if (!soundsEnabled) return
     try {
       const audioContext = new (window.AudioContext || window.webkitAudioContext)()
-      
-      // Create a triumphant "tadah" fanfare sound
-      const playNote = (frequency, startTime, duration, volume = 0.2) => {
+
+      const playNote = (frequency, startTime, duration, volume = 0.25) => {
         const oscillator = audioContext.createOscillator()
         const gainNode = audioContext.createGain()
-        
+
         oscillator.connect(gainNode)
         gainNode.connect(audioContext.destination)
-        
+
         oscillator.frequency.setValueAtTime(frequency, startTime)
-        oscillator.type = 'sawtooth' // Richer, more fanfare-like sound
-        
+        oscillator.type = 'triangle'
+
         gainNode.gain.setValueAtTime(0, startTime)
-        gainNode.gain.linearRampToValueAtTime(volume, startTime + 0.02)
+        gainNode.gain.linearRampToValueAtTime(volume, startTime + 0.01)
         gainNode.gain.exponentialRampToValueAtTime(0.01, startTime + duration)
-        
+
         oscillator.start(startTime)
         oscillator.stop(startTime + duration)
       }
-      
-      // Create chord progression for "tadah" effect
+
       const now = audioContext.currentTime
-      
-      // Opening chord (C major) - quick stab
-      playNote(261.63, now, 0.15, 0.15) // C4
-      playNote(329.63, now, 0.15, 0.12) // E4
-      playNote(392.00, now, 0.15, 0.12) // G4
-      
-      // Rising glissando effect
-      playNote(523.25, now + 0.2, 0.3, 0.2) // C5
-      playNote(587.33, now + 0.35, 0.3, 0.18) // D5
-      playNote(659.25, now + 0.5, 0.4, 0.22) // E5
-      
-      // Final triumphant chord (C major octave higher) - "TADAH!"
-      playNote(523.25, now + 0.8, 0.8, 0.25) // C5
-      playNote(659.25, now + 0.8, 0.8, 0.2)  // E5
-      playNote(783.99, now + 0.8, 0.8, 0.2)  // G5
-      playNote(1046.5, now + 0.8, 0.8, 0.15) // C6
-      
+
+      // Simple two-note "tadah"
+      playNote(523.25, now, 0.25)
+      playNote(659.25, now + 0.25, 0.3)
+
     } catch (error) {
       console.log('Audio not supported:', error)
-      // Fallback: try to use system bell
       console.log('\u0007') // Bell character
     }
   }
@@ -248,6 +259,7 @@ function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted, onPomodoroCompl
       const selected = tasks[selectedIndex]
       setSelectedTask(selected)
       onTaskSelected(selected)
+      playSelectionSound()
     }, 4000)
   }
 


### PR DESCRIPTION
## Summary
- add a quick chime when the wheel finishes spinning
- shorten timer "tadah" tune

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685760bf1bf88333b2cf881e4dc750aa