### PR TITLE
Add Jest tests

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub'

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }]
+  ]
+}

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '\\.(css|less|sass|scss)$': '<rootDir>/__mocks__/styleMock.js',
+    '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/__mocks__/fileMock.js'
+  },
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest'
+  }
+}

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.10",
@@ -24,6 +25,13 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/user-event": "^14.6.2",
+    "babel-jest": "^29.7.0",
+    "@babel/preset-env": "^7.24.5",
+    "@babel/preset-react": "^7.22.5"
   }
 }

--- a/src/__tests__/app.test.jsx
+++ b/src/__tests__/app.test.jsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import App from '../App'
+
+beforeEach(() => {
+  localStorage.clear()
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  jest.runOnlyPendingTimers()
+  jest.useRealTimers()
+})
+
+async function addTask(text) {
+  const input = screen.getByPlaceholderText(/enter a new task/i)
+  await userEvent.type(input, text)
+  await userEvent.click(screen.getByRole('button', { name: /add/i }))
+}
+
+test('adding and deleting a task', async () => {
+  render(<App />)
+  await addTask('Task 1')
+  expect(screen.getByText('Task 1')).toBeInTheDocument()
+  window.confirm = jest.fn(() => true)
+  await userEvent.click(screen.getByLabelText("Delete task 'Task 1'"))
+  expect(screen.queryByText('Task 1')).not.toBeInTheDocument()
+})
+
+test('start timer from task list', async () => {
+  render(<App />)
+  await addTask('Task 1')
+  await userEvent.click(screen.getByLabelText("Start timer for task 'Task 1'"))
+  expect(await screen.findByText(/selected task/i)).toBeInTheDocument()
+  expect(screen.getByText('Task 1')).toBeInTheDocument()
+})
+
+test('spinning the wheel and starting timer', async () => {
+  render(<App />)
+  await addTask('Task 1')
+  await addTask('Task 2')
+  await userEvent.click(screen.getByRole('button', { name: /spin the wheel/i }))
+  jest.advanceTimersByTime(4000)
+  expect(await screen.findByText(/selected task/i)).toBeInTheDocument()
+  await userEvent.click(screen.getByRole('button', { name: /start timer/i }))
+  expect(screen.getByText('25:00')).toBeInTheDocument()
+})
+
+test('completed tasks appear and paginate with analytics', async () => {
+  localStorage.setItem('rouletteSettings', JSON.stringify({ soundsEnabled: true, pomodoroDuration: 1 }))
+  render(<App />)
+  for (let i = 1; i <= 6; i++) {
+    await addTask('Task ' + i)
+    await userEvent.click(screen.getByLabelText(`Start timer for task 'Task ${i}'`))
+    await userEvent.click(await screen.findByRole('button', { name: /start timer/i }))
+    jest.advanceTimersByTime(60000)
+    await screen.findByText(/time for a 1-minute pomodoro session!/i)
+    window.confirm = jest.fn(() => true)
+    await userEvent.click(screen.getByRole('button', { name: /complete task/i }))
+  }
+  expect(screen.getByText(/completed tasks \(6\)/i)).toBeInTheDocument()
+  expect(screen.getByText(/pomodoros today: 6/i)).toBeInTheDocument()
+  const next = screen.getByRole('button', { name: /next/i })
+  expect(next).not.toBeDisabled()
+  await userEvent.click(next)
+  expect(screen.getByRole('button', { name: /prev/i })).not.toBeDisabled()
+})


### PR DESCRIPTION
## Summary
- configure Jest and testing libraries
- add placeholder mocks and Babel/Jest setup
- write initial tests for basic app functionality
- provide `npm test` script

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68575f91fa2c8333bac2d7f36e5a37cf