### PR TITLE
Switch to canvas-based wheel

### DIFF
--- a/src/components/RouletteWheel.jsx
+++ b/src/components/RouletteWheel.jsx
@@ -6,6 +6,7 @@ import SettingsModal from './SettingsModal'
 import PomodoroTimer from './PomodoroTimer'
 import usePomodoroTimer from '../hooks/usePomodoroTimer'
 import useSettings from '../hooks/useSettings'
+import WheelCanvas from './WheelCanvas'
 
 function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted, onPomodoroComplete, startTaskId, onStartTaskConsumed }) {
   const [isSpinning, setIsSpinning] = useState(false)
@@ -291,47 +292,8 @@ function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted, onPomodoroCompl
               </div>
 
               {/* Wheel */}
-              <div
-                ref={wheelRef}
-                className="w-80 h-80 rounded-full border-4 border-gray-600 relative overflow-hidden transition-transform duration-[4000ms] ease-out"
-                style={{
-                  background: `conic-gradient(${tasks.map((task, index) => {
-                    const startAngle = (index * 360) / tasks.length
-                    const endAngle = ((index + 1) * 360) / tasks.length
-                    const color = colors[index % colors.length]
-                    return `${color} ${startAngle}deg ${endAngle}deg`
-                  }).join(', ')})`
-                }}
-              >
-                {/* Task Labels */}
-                {tasks.map((task, index) => {
-                  const degreesPerTask = 360 / tasks.length
-                  const angle = (index * degreesPerTask) + (degreesPerTask / 2)
-                  const radius = 85
-                  const x = Math.cos((angle - 90) * Math.PI / 180) * radius
-                  const y = Math.sin((angle - 90) * Math.PI / 180) * radius
-
-                  return (
-                    <div
-                      key={task.id}
-                      className="absolute text-white text-sm font-bold pointer-events-none select-none"
-                      style={{
-                        left: '50%',
-                        top: '50%',
-                        transform: `translate(calc(-50% + ${x}px), calc(-50% + ${y}px))`,
-                        textShadow: '2px 2px 4px rgba(0,0,0,0.8)',
-                        maxWidth: '80px',
-                        textAlign: 'center',
-                        lineHeight: '1.1',
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis'
-                      }}
-                    >
-                      {task.text.length > 15 ? task.text.substring(0, 15) + '...' : task.text}
-                    </div>
-                  )
-                })}
+              <div ref={wheelRef} className="transition-transform duration-[4000ms] ease-out">
+                <WheelCanvas tasks={tasks} colors={colors} />
               </div>
             </div>
           </div>

--- a/src/components/WheelCanvas.jsx
+++ b/src/components/WheelCanvas.jsx
@@ -1,0 +1,49 @@
+import { useRef, useEffect } from 'react'
+
+function WheelCanvas({ tasks, colors = [] }) {
+  const canvasRef = useRef(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    const size = canvas.width
+    const radius = size / 2
+    ctx.clearRect(0, 0, size, size)
+
+    if (tasks.length === 0) return
+
+    tasks.forEach((task, index) => {
+      const startAngle = (index / tasks.length) * 2 * Math.PI
+      const endAngle = ((index + 1) / tasks.length) * 2 * Math.PI
+
+      ctx.beginPath()
+      ctx.moveTo(radius, radius)
+      ctx.arc(radius, radius, radius, startAngle, endAngle)
+      ctx.closePath()
+      ctx.fillStyle = colors[index % colors.length] || '#888'
+      ctx.fill()
+
+      ctx.save()
+      ctx.translate(radius, radius)
+      ctx.rotate((startAngle + endAngle) / 2)
+      ctx.fillStyle = '#fff'
+      ctx.font = 'bold 14px sans-serif'
+      ctx.textAlign = 'right'
+      const text = task.text.length > 15 ? task.text.substring(0, 15) + '\u2026' : task.text
+      ctx.fillText(text, radius - 10, 4)
+      ctx.restore()
+    })
+  }, [tasks, colors])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={320}
+      height={320}
+      className="w-80 h-80 rounded-full border-4 border-gray-600"
+    />
+  )
+}
+
+export default WheelCanvas


### PR DESCRIPTION
## Summary
- import new `WheelCanvas` component
- use the canvas wheel instead of CSS conic gradient wheel
- implement `WheelCanvas` component to draw tasks on `<canvas>`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68577013b9b08333a002d40cbb11b094