### PR TITLE
Add onboarding placeholder tasks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,25 @@ function App() {
     setTasks(prev => prev.map(t => ({ pomodoros: t.pomodoros || 0, ...t })))
   }, [])
 
+  useEffect(() => {
+    try {
+      const hasUsedApp = localStorage.getItem('hasUsedApp')
+      if (!hasUsedApp) {
+        if (tasks.length === 0) {
+          const now = Date.now()
+          const placeholders = [
+            { id: now, text: 'Learn how to use the app.', createdAt: new Date(), pomodoros: 0 },
+            { id: now + 1, text: 'Delete these placeholder tasks.', createdAt: new Date(), pomodoros: 0 },
+          ]
+          setTasks(placeholders)
+        }
+        localStorage.setItem('hasUsedApp', 'true')
+      }
+    } catch {
+      // ignore localStorage errors
+    }
+  }, [])
+
 
   const addTask = (taskText) => {
     const newTask = {


### PR DESCRIPTION
## Summary
- add default onboarding tasks on initial load when app hasn't been used

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857f0f36d3083339f4ead7e9ad4a3e4