### PR TITLE
Fix pomodoro count when finishing task

### DIFF
--- a/src/components/RouletteWheel.jsx
+++ b/src/components/RouletteWheel.jsx
@@ -182,6 +182,10 @@ function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted, onPomodoroCompl
     )
 
     if (confirmed) {
+      const wasPomodoroStarted = timerStarted || timeLeft > 0
+      if (wasPomodoroStarted && onPomodoroComplete) {
+        onPomodoroComplete(selectedTask.id)
+      }
       resetTimer()
       setSelectedTask(null)
       if (onTaskCompleted) {


### PR DESCRIPTION
## Summary
- ensure completing a task with an active timer counts the running pomodoro

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685806a1b668833396f18b55fceaf786