### PR TITLE
Add break timer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ https://pomodo-roulette.netlify.app/
 - Amazing :tada: Sound effects for the wheel and timer
 - Track completed tasks and how many pomodoros each took
 - Daily count of completed pomodoros
+- Configurable break timer after each pomodoro

--- a/src/components/BreakTimer.jsx
+++ b/src/components/BreakTimer.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+
+function BreakTimer({
+  timeLeft,
+  timerStarted,
+  isPaused,
+  breakDuration,
+  onStartBreak,
+  onPauseBreak,
+  onResumeBreak,
+  onEndBreak,
+}) {
+  const formatTime = (seconds) => {
+    const m = String(Math.floor(seconds / 60)).padStart(2, '0')
+    const s = String(seconds % 60).padStart(2, '0')
+    return `${m}:${s}`
+  }
+
+  if (timeLeft === 0 && !timerStarted) {
+    return (
+      <div className="text-center p-4 mx-auto mt-6 w-4/5 rounded-md backdrop-blur-md bg-[rgba(34,44,60,0.45)] border-2 border-accent-success">
+        <p className="text-sm text-green-300 mt-2">Time for a {breakDuration}-minute break!</p>
+        <div className="mt-4 flex justify-center">
+          <button
+            onClick={onStartBreak}
+            className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+          >
+            Start Break
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="text-center p-4 mx-auto mt-6 w-4/5 rounded-md backdrop-blur-md bg-[rgba(34,44,60,0.45)] border-2 border-accent-success">
+      <p className="text-2xl font-bold text-green-300 mt-2">{formatTime(timeLeft)}</p>
+      <div className="mt-4 flex justify-center space-x-4">
+        <button
+          onClick={isPaused ? onResumeBreak : onPauseBreak}
+          className="px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600 transition-colors"
+        >
+          {isPaused ? 'Resume' : 'Pause'}
+        </button>
+        <button
+          onClick={onEndBreak}
+          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+        >
+          End Break
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default BreakTimer

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,11 +1,22 @@
 import { useState } from 'react'
 
-function SettingsModal({ initialSoundsEnabled, initialPomodoroDuration, onSave, onClose }) {
+function SettingsModal({
+  initialSoundsEnabled,
+  initialPomodoroDuration,
+  initialBreakDuration,
+  onSave,
+  onClose,
+}) {
   const [sounds, setSounds] = useState(initialSoundsEnabled)
   const [duration, setDuration] = useState(initialPomodoroDuration)
+  const [breakDuration, setBreakDuration] = useState(initialBreakDuration)
 
   const handleSave = () => {
-    onSave({ soundsEnabled: sounds, pomodoroDuration: duration })
+    onSave({
+      soundsEnabled: sounds,
+      pomodoroDuration: duration,
+      breakDuration,
+    })
     onClose()
   }
 
@@ -30,6 +41,16 @@ function SettingsModal({ initialSoundsEnabled, initialPomodoroDuration, onSave, 
             min="1"
             value={duration}
             onChange={(e) => setDuration(Number(e.target.value))}
+            className="w-full px-2 py-1 rounded bg-bg-secondary"
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block mb-1">Break Duration (minutes)</label>
+          <input
+            type="number"
+            min="1"
+            value={breakDuration}
+            onChange={(e) => setBreakDuration(Number(e.target.value))}
             className="w-full px-2 py-1 rounded bg-bg-secondary"
           />
         </div>

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -4,6 +4,7 @@ export default function useSettings() {
   const [settings, setSettings] = useLocalStorage('rouletteSettings', {
     soundsEnabled: true,
     pomodoroDuration: 25,
+    breakDuration: 5,
   })
 
   const setSoundsEnabled = (enabled) => {
@@ -14,10 +15,16 @@ export default function useSettings() {
     setSettings((prev) => ({ ...prev, pomodoroDuration: duration }))
   }
 
+  const setBreakDuration = (duration) => {
+    setSettings((prev) => ({ ...prev, breakDuration: duration }))
+  }
+
   return {
     soundsEnabled: settings.soundsEnabled,
     pomodoroDuration: settings.pomodoroDuration,
+    breakDuration: settings.breakDuration,
     setSoundsEnabled,
     setPomodoroDuration,
+    setBreakDuration,
   }
 }


### PR DESCRIPTION
## Summary
- add configurable break timer to settings (default 5 minutes)
- implement `BreakTimer` component
- integrate break logic in `RouletteWheel`
- expose break duration setting in modal
- update README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6858089d78808333b6ffe81b0ce0faac