### PR TITLE
Add persistent active pomodoro timer

### DIFF
--- a/src/hooks/usePomodoroTimer.js
+++ b/src/hooks/usePomodoroTimer.js
@@ -13,6 +13,13 @@ export default function usePomodoroTimer(durationMinutes, onComplete) {
     setIsPaused(false)
   }
 
+  const startTimerWithSeconds = (seconds) => {
+    clearTimeout(timerRef.current)
+    setTimeLeft(seconds)
+    setTimerStarted(true)
+    setIsPaused(false)
+  }
+
   const pauseTimer = () => {
     clearTimeout(timerRef.current)
     setIsPaused(true)
@@ -49,6 +56,7 @@ export default function usePomodoroTimer(durationMinutes, onComplete) {
     timerStarted,
     isPaused,
     startTimer,
+    startTimerWithSeconds,
     pauseTimer,
     resumeTimer,
     reset,


### PR DESCRIPTION
## Summary
- persist active Pomodoro sessions in `localStorage`
- resume active timer on page load if it hasn't expired
- expose `startTimerWithSeconds` in `usePomodoroTimer`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858091c802c83338905691b4c67340a