### PR TITLE
Add timer progress bar to Pomodoro and break sessions

### DIFF
--- a/src/components/RouletteWheel.jsx
+++ b/src/components/RouletteWheel.jsx
@@ -5,6 +5,7 @@ import SettingsIcon from './icons/SettingsIcon'
 import SettingsModal from './SettingsModal'
 import PomodoroTimer from './PomodoroTimer'
 import BreakTimer from './BreakTimer'
+import TimerProgressBar from './TimerProgressBar'
 import usePomodoroTimer from '../hooks/usePomodoroTimer'
 import useSettings from '../hooks/useSettings'
 import WheelCanvas from './WheelCanvas'
@@ -330,6 +331,13 @@ function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted, onPomodoroCompl
 
   return (
     <>
+    {(timerStarted || breakTimerStarted) && (
+      <TimerProgressBar
+        timeLeft={timerStarted ? timeLeft : breakTimeLeft}
+        totalTime={(timerStarted ? pomodoroDuration : breakDuration) * 60}
+        mode={timerStarted ? 'task' : 'break'}
+      />
+    )}
     <div className="bg-bg-card rounded-md shadow-lg px-6 py-12 relative">
       <button
         aria-label="Settings"

--- a/src/components/TimerProgressBar.jsx
+++ b/src/components/TimerProgressBar.jsx
@@ -3,7 +3,8 @@ import React from 'react'
 function TimerProgressBar({ timeLeft, totalTime, mode }) {
   if (totalTime <= 0) return null
   const percentage = Math.max(0, Math.min(1, timeLeft / totalTime)) * 100
-  const fgColor = mode === 'break' ? '#f97316' : 'var(--color-accent-success)'
+  const fgColor =
+    mode === 'break' ? 'var(--color-accent-info)' : 'var(--color-accent-success)'
   return (
     <div className="fixed top-0 left-0 w-full h-2 bg-accent-primary z-50">
       <div

--- a/src/components/TimerProgressBar.jsx
+++ b/src/components/TimerProgressBar.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+function TimerProgressBar({ timeLeft, totalTime, mode }) {
+  if (totalTime <= 0) return null
+  const percentage = Math.max(0, Math.min(1, timeLeft / totalTime)) * 100
+  const fgColor = mode === 'break' ? '#f97316' : 'var(--color-accent-success)'
+  return (
+    <div className="fixed top-0 left-0 w-full h-2 bg-accent-primary z-50">
+      <div
+        className="h-full transition-all duration-1000"
+        style={{ width: `${percentage}%`, backgroundColor: fgColor }}
+      />
+    </div>
+  )
+}
+
+export default TimerProgressBar


### PR DESCRIPTION
## Summary
- show a progress bar whenever a task or break timer runs
- style the bar with a red background and change its color based on timer type

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68580fd0acf8833394fae8a081ed03f0