### PR TITLE
Disable wheel spin while timer running

### DIFF
--- a/src/components/RouletteWheel.jsx
+++ b/src/components/RouletteWheel.jsx
@@ -388,9 +388,9 @@ function RouletteWheel({ tasks, onTaskSelected, onTaskCompleted, onPomodoroCompl
           <div className="text-center mb-4">
             <button
               onClick={spin}
-              disabled={isSpinning}
+              disabled={isSpinning || timerStarted}
               className={`px-8 h-12 rounded-pill inline-flex items-center justify-center gap-2 font-medium transition-all ${
-                isSpinning
+                isSpinning || timerStarted
                   ? 'bg-gray-600 cursor-not-allowed'
                   : 'bg-gradient-to-r from-accent-success to-green-700 hover:brightness-110 active:brightness-90'
               } text-white focus:outline-none focus:ring-2 focus:ring-accent-success`}


### PR DESCRIPTION
## Summary
- disable the **Spin the Wheel** button when a Pomodoro timer is active

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858379a8f5c8333a5a9df93aed9fbe6