### PR TITLE
Add export insights button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import useLocalStorage from "./hooks/useLocalStorage";
 import TaskManager from "./components/TaskManager";
 import RouletteWheel from "./components/RouletteWheel";
 import AnalyticsPanel from "./components/AnalyticsPanel";
+import useInsights from "./hooks/useInsights";
 import TomatoIcon from "./components/icons/TomatoIcon";
 
 function App() {
@@ -21,6 +22,8 @@ function App() {
   };
   const [selectedTask, setSelectedTask] = useState(null);
   const [startTaskId, setStartTaskId] = useState(null);
+  const { generateInsights } = useInsights();
+  const [insights, setInsights] = useState('');
 
   useEffect(() => {
     setTasks(prev => prev.map(t => ({ pomodoros: t.pomodoros || 0, ...t })))
@@ -120,6 +123,22 @@ function App() {
               onReorderTasks={reorderTasks}
             />
            <AnalyticsPanel completedTasks={completedTasks} dailyPomodoros={dailyPomodoros} />
+           <button
+              type="button"
+              onClick={() => setInsights(generateInsights())}
+              className="mt-4 px-4 py-2 bg-accent-info text-white rounded hover:bg-accent-info/80"
+           >
+              Export data insights
+           </button>
+           {insights && (
+             <textarea
+               readOnly
+               value={insights}
+               onFocus={(e) => e.target.select()}
+               className="mt-2 w-full p-2 rounded bg-bg-secondary text-white text-sm"
+               rows="6"
+             />
+           )}
            </div>
 
            {/* Right Side - Roulette Wheel */}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -10,43 +10,6 @@ function SettingsModal({
   const [sounds, setSounds] = useState(initialSoundsEnabled)
   const [duration, setDuration] = useState(initialPomodoroDuration)
   const [breakDuration, setBreakDuration] = useState(initialBreakDuration)
-  const [insights, setInsights] = useState('')
-
-  const generateInsights = () => {
-    try {
-      const tasks = JSON.parse(localStorage.getItem('tasks') || '[]')
-      const completed = JSON.parse(localStorage.getItem('completedTasks') || '[]')
-      const all = [...tasks, ...completed]
-      const totalPomodoros = all.reduce((sum, t) => sum + (t.pomodoros || 0), 0)
-      const now = new Date()
-      const pomodorosByDay = Array(7).fill(0)
-      let firstDate = null
-      completed.forEach(t => {
-        const date = new Date(t.completedAt)
-        if (!firstDate || date < firstDate) firstDate = date
-        pomodorosByDay[date.getDay()] += t.pomodoros || 0
-      })
-      const daysSinceFirst = firstDate ? Math.max(1, Math.ceil((now - firstDate) / (24 * 60 * 60 * 1000))) : 1
-      const avgPerDay = (totalPomodoros / daysSinceFirst).toFixed(2)
-      const mostProductiveIndex = pomodorosByDay.indexOf(Math.max(...pomodorosByDay))
-      const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
-      const productiveDay = dayNames[mostProductiveIndex] || 'N/A'
-      const weekAgo = now.getTime() - 7 * 24 * 60 * 60 * 1000
-      const monthAgo = now.getTime() - 30 * 24 * 60 * 60 * 1000
-      const yearAgo = now.getTime() - 365 * 24 * 60 * 60 * 1000
-      const tasksWeek = completed.filter(t => new Date(t.completedAt).getTime() >= weekAgo).length
-      const tasksMonth = completed.filter(t => new Date(t.completedAt).getTime() >= monthAgo).length
-      const tasksYear = completed.filter(t => new Date(t.completedAt).getTime() >= yearAgo).length
-      const hours = ((totalPomodoros * 25) / 60).toFixed(2)
-      return `You completed ${totalPomodoros} pomodoros, on average you complete ${avgPerDay} pomodoros per day, your most productive day of the week is ${productiveDay}, in the past week you completed ${tasksWeek} tasks, in the past month you completed ${tasksMonth} tasks, in the past year you completed ${tasksYear} tasks, and in total you completed ${completed.length} tasks and ${totalPomodoros} pomodoros, this is about ${hours} hours of focused work.`
-    } catch {
-      return 'Unable to generate insights. Your browser may not allow access to local data.'
-    }
-  }
-
-  const handleExport = () => {
-    setInsights(generateInsights())
-  }
 
   const handleSave = () => {
     onSave({
@@ -104,23 +67,7 @@ function SettingsModal({
           >
             Save
           </button>
-          <button
-            onClick={handleExport}
-            type="button"
-            className="px-4 py-2 bg-accent-info text-white rounded hover:bg-accent-info/80"
-          >
-            Export data insights
-          </button>
         </div>
-        {insights && (
-          <textarea
-            readOnly
-            value={insights}
-            onFocus={(e) => e.target.select()}
-            className="mt-4 w-full p-2 rounded bg-bg-secondary text-white text-sm"
-            rows="6"
-          />
-        )}
       </div>
     </div>
   )

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -10,6 +10,43 @@ function SettingsModal({
   const [sounds, setSounds] = useState(initialSoundsEnabled)
   const [duration, setDuration] = useState(initialPomodoroDuration)
   const [breakDuration, setBreakDuration] = useState(initialBreakDuration)
+  const [insights, setInsights] = useState('')
+
+  const generateInsights = () => {
+    try {
+      const tasks = JSON.parse(localStorage.getItem('tasks') || '[]')
+      const completed = JSON.parse(localStorage.getItem('completedTasks') || '[]')
+      const all = [...tasks, ...completed]
+      const totalPomodoros = all.reduce((sum, t) => sum + (t.pomodoros || 0), 0)
+      const now = new Date()
+      const pomodorosByDay = Array(7).fill(0)
+      let firstDate = null
+      completed.forEach(t => {
+        const date = new Date(t.completedAt)
+        if (!firstDate || date < firstDate) firstDate = date
+        pomodorosByDay[date.getDay()] += t.pomodoros || 0
+      })
+      const daysSinceFirst = firstDate ? Math.max(1, Math.ceil((now - firstDate) / (24 * 60 * 60 * 1000))) : 1
+      const avgPerDay = (totalPomodoros / daysSinceFirst).toFixed(2)
+      const mostProductiveIndex = pomodorosByDay.indexOf(Math.max(...pomodorosByDay))
+      const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+      const productiveDay = dayNames[mostProductiveIndex] || 'N/A'
+      const weekAgo = now.getTime() - 7 * 24 * 60 * 60 * 1000
+      const monthAgo = now.getTime() - 30 * 24 * 60 * 60 * 1000
+      const yearAgo = now.getTime() - 365 * 24 * 60 * 60 * 1000
+      const tasksWeek = completed.filter(t => new Date(t.completedAt).getTime() >= weekAgo).length
+      const tasksMonth = completed.filter(t => new Date(t.completedAt).getTime() >= monthAgo).length
+      const tasksYear = completed.filter(t => new Date(t.completedAt).getTime() >= yearAgo).length
+      const hours = ((totalPomodoros * 25) / 60).toFixed(2)
+      return `You completed ${totalPomodoros} pomodoros, on average you complete ${avgPerDay} pomodoros per day, your most productive day of the week is ${productiveDay}, in the past week you completed ${tasksWeek} tasks, in the past month you completed ${tasksMonth} tasks, in the past year you completed ${tasksYear} tasks, and in total you completed ${completed.length} tasks and ${totalPomodoros} pomodoros, this is about ${hours} hours of focused work.`
+    } catch {
+      return 'Unable to generate insights. Your browser may not allow access to local data.'
+    }
+  }
+
+  const handleExport = () => {
+    setInsights(generateInsights())
+  }
 
   const handleSave = () => {
     onSave({
@@ -67,7 +104,23 @@ function SettingsModal({
           >
             Save
           </button>
+          <button
+            onClick={handleExport}
+            type="button"
+            className="px-4 py-2 bg-accent-info text-white rounded hover:bg-accent-info/80"
+          >
+            Export data insights
+          </button>
         </div>
+        {insights && (
+          <textarea
+            readOnly
+            value={insights}
+            onFocus={(e) => e.target.select()}
+            className="mt-4 w-full p-2 rounded bg-bg-secondary text-white text-sm"
+            rows="6"
+          />
+        )}
       </div>
     </div>
   )

--- a/src/hooks/useInsights.js
+++ b/src/hooks/useInsights.js
@@ -1,0 +1,37 @@
+import { useCallback } from 'react'
+
+export default function useInsights() {
+  const generateInsights = useCallback(() => {
+    try {
+      const tasks = JSON.parse(localStorage.getItem('tasks') || '[]')
+      const completed = JSON.parse(localStorage.getItem('completedTasks') || '[]')
+      const all = [...tasks, ...completed]
+      const totalPomodoros = all.reduce((sum, t) => sum + (t.pomodoros || 0), 0)
+      const now = new Date()
+      const pomodorosByDay = Array(7).fill(0)
+      let firstDate = null
+      completed.forEach(t => {
+        const date = new Date(t.completedAt)
+        if (!firstDate || date < firstDate) firstDate = date
+        pomodorosByDay[date.getDay()] += t.pomodoros || 0
+      })
+      const daysSinceFirst = firstDate ? Math.max(1, Math.ceil((now - firstDate) / (24 * 60 * 60 * 1000))) : 1
+      const avgPerDay = (totalPomodoros / daysSinceFirst).toFixed(2)
+      const mostProductiveIndex = pomodorosByDay.indexOf(Math.max(...pomodorosByDay))
+      const dayNames = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday']
+      const productiveDay = dayNames[mostProductiveIndex] || 'N/A'
+      const weekAgo = now.getTime() - 7 * 24 * 60 * 60 * 1000
+      const monthAgo = now.getTime() - 30 * 24 * 60 * 60 * 1000
+      const yearAgo = now.getTime() - 365 * 24 * 60 * 60 * 1000
+      const tasksWeek = completed.filter(t => new Date(t.completedAt).getTime() >= weekAgo).length
+      const tasksMonth = completed.filter(t => new Date(t.completedAt).getTime() >= monthAgo).length
+      const tasksYear = completed.filter(t => new Date(t.completedAt).getTime() >= yearAgo).length
+      const hours = ((totalPomodoros * 25) / 60).toFixed(2)
+      return `You completed ${totalPomodoros} pomodoros, on average you complete ${avgPerDay} pomodoros per day, your most productive day of the week is ${productiveDay}, in the past week you completed ${tasksWeek} tasks, in the past month you completed ${tasksMonth} tasks, in the past year you completed ${tasksYear} tasks, and in total you completed ${completed.length} tasks and ${totalPomodoros} pomodoros, this is about ${hours} hours of focused work.`
+    } catch {
+      return 'Unable to generate insights. Your browser may not allow access to local data.'
+    }
+  }, [])
+
+  return { generateInsights }
+}


### PR DESCRIPTION
## Summary
- add data insight generation logic
- expose Export data insights button in Settings modal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685838706ca48333b977da10d62b49f9