### PR TITLE
Fix Pomodoro timer freeze on page background

### DIFF
--- a/src/hooks/usePomodoroTimer.js
+++ b/src/hooks/usePomodoroTimer.js
@@ -64,6 +64,23 @@ export default function usePomodoroTimer(durationMinutes, onComplete) {
     return () => clearTimer()
   }, [])
 
+  // Ensure the timer updates when the page becomes visible again
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        updateTimeLeft()
+        // If the timer should be running but no interval is active, start it
+        if (timerStarted && !isPaused && !intervalRef.current) {
+          intervalRef.current = setInterval(updateTimeLeft, 1000)
+        }
+      }
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [timerStarted, isPaused])
+
   return {
     timeLeft,
     timerStarted,

--- a/src/hooks/usePomodoroTimer.js
+++ b/src/hooks/usePomodoroTimer.js
@@ -6,11 +6,14 @@ export default function usePomodoroTimer(durationMinutes, onComplete) {
   const [isPaused, setIsPaused] = useState(false)
 
   const intervalRef = useRef(null)
+  const timeoutRef = useRef(null)
   const endTimeRef = useRef(null)
 
   const clearTimer = () => {
     clearInterval(intervalRef.current)
+    clearTimeout(timeoutRef.current)
     intervalRef.current = null
+    timeoutRef.current = null
   }
 
   const updateTimeLeft = () => {
@@ -36,6 +39,9 @@ export default function usePomodoroTimer(durationMinutes, onComplete) {
     setTimerStarted(true)
     setIsPaused(false)
     intervalRef.current = setInterval(updateTimeLeft, 1000)
+    timeoutRef.current = setTimeout(() => {
+      updateTimeLeft()
+    }, durationMs + 100)
   }
 
   const pauseTimer = () => {
@@ -50,6 +56,9 @@ export default function usePomodoroTimer(durationMinutes, onComplete) {
     endTimeRef.current = Date.now() + timeLeft * 1000
     setIsPaused(false)
     intervalRef.current = setInterval(updateTimeLeft, 1000)
+    timeoutRef.current = setTimeout(() => {
+      updateTimeLeft()
+    }, timeLeft * 1000 + 100)
   }
 
   const reset = () => {

--- a/src/hooks/usePomodoroTimer.js
+++ b/src/hooks/usePomodoroTimer.js
@@ -73,23 +73,6 @@ export default function usePomodoroTimer(durationMinutes, onComplete) {
     return () => clearTimer()
   }, [])
 
-  // Ensure the timer updates when the page becomes visible again
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (!document.hidden) {
-        updateTimeLeft()
-        // If the timer should be running but no interval is active, start it
-        if (timerStarted && !isPaused && !intervalRef.current) {
-          intervalRef.current = setInterval(updateTimeLeft, 1000)
-        }
-      }
-    }
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-    return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
-    }
-  }, [timerStarted, isPaused])
-
   return {
     timeLeft,
     timerStarted,


### PR DESCRIPTION
## Summary
- ensure timers update after returning from background

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68583b6acfb48333b5fa1b1b598deddf