### PR TITLE
Change break progress bar color

### DIFF
--- a/src/components/TimerProgressBar.jsx
+++ b/src/components/TimerProgressBar.jsx
@@ -4,7 +4,7 @@ function TimerProgressBar({ timeLeft, totalTime, mode }) {
   if (totalTime <= 0) return null
   const percentage = Math.max(0, Math.min(1, timeLeft / totalTime)) * 100
   const fgColor =
-    mode === 'break' ? 'var(--color-accent-info)' : 'var(--color-accent-success)'
+    mode === 'break' ? 'var(--color-accent-break)' : 'var(--color-accent-success)'
   return (
     <div className="fixed top-0 left-0 w-full h-2 bg-accent-primary z-50">
       <div

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
   --color-accent-primary: #FF5B57;
   --color-accent-success: #22C55E;
   --color-accent-info: #38BDF8;
+  --color-accent-break: #a855f7;
   --color-text-primary: rgba(255,255,255,0.87);
   --border-radius-md: 12px;
   --border-radius-pill: 24px;


### PR DESCRIPTION
## Summary
- add accent-break color variable
- use accent-break for break progress bar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68585a2707108333bfba766606c210aa